### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "libfxdiv"
+description := "A library for division via fixed-point multiplication by inverse."
+gitrepo     := "https://github.com/Maratyszcza/FXdiv.git"
+homepage    := "https://github.com/Maratyszcza/FXdiv/"
+version     := f8c5354 sha256:7d3215bea832fe77091ec5666200b91156df6724da1e348205078346325fc45e https://github.com/Maratyszcza/FXdiv/archive/f8c5354.tar.gz
+license     := "MIT"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

